### PR TITLE
Task #004 | Manage start chat via socket

### DIFF
--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -6,8 +6,8 @@ import {
   WebSocketServer,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
-import { Logger } from '@nestjs/common';
-import { IUser, ActionTypes } from '@chat-app/api-interface';
+import { HttpService, Logger } from '@nestjs/common';
+import { IUser, ActionTypes, IChat } from '@chat-app/api-interface';
 
 @WebSocketGateway()
 export class AppGateway {
@@ -15,6 +15,8 @@ export class AppGateway {
   server: Server;
   private logger: Logger = new Logger('AppGateway');
   private connectedClients: IUser[] = [];
+
+  constructor(private httpService: HttpService) {}
 
   handleDisconnect(client: Socket) {
     this.connectedClients = this.connectedClients.filter(
@@ -43,5 +45,8 @@ export class AppGateway {
     this.logger.log(
       `Start Chat: Between ${payload.participants[0]._id} and ${payload.participants[1]._id}`
     );
+    this.httpService
+      .post<IChat>('http://localhost:3333/api/chats', payload)
+      .subscribe();
   }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -55,6 +55,7 @@ export class AppGateway {
             socket.join(chat._id);
           }
         });
+        this.server.to(chat._id).emit(ActionTypes.ChatStarted, { chat });
       });
   }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -47,6 +47,14 @@ export class AppGateway {
     );
     this.httpService
       .post<IChat>('http://localhost:3333/api/chats', payload)
-      .subscribe();
+      .subscribe(({ data: chat }) => {
+        // Add both participants to the chat room
+        payload.participants.forEach((participant) => {
+          const socket = this.server.sockets.connected[participant.clientId];
+          if (socket) {
+            socket.join(chat._id);
+          }
+        });
+      });
   }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -37,4 +37,11 @@ export class AppGateway {
     );
     this.server.emit(ActionTypes.ClientsUpdated, this.connectedClients);
   }
+
+  @SubscribeMessage(ActionTypes.StartChat)
+  startChat(@MessageBody() payload: { participants: [IUser, IUser] }) {
+    this.logger.log(
+      `Start Chat: Between ${payload.participants[0]._id} and ${payload.participants[1]._id}`
+    );
+  }
 }

--- a/apps/comm/src/app/app.module.ts
+++ b/apps/comm/src/app/app.module.ts
@@ -1,8 +1,8 @@
-import { Module } from '@nestjs/common';
+import { HttpModule, Module } from '@nestjs/common';
 import { AppGateway } from './app.gateway';
 
 @Module({
-  imports: [],
+  imports: [HttpModule],
   controllers: [],
   providers: [AppGateway],
 })

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -4,9 +4,13 @@ import { createEffect, Actions, ofType } from '@ngrx/effects';
 import { map, mergeMap, tap } from 'rxjs/operators';
 import { Socket } from 'ngx-socket-io';
 
-import { HomePageActions, ChatsApiActions } from '../../home/actions';
+import {
+  HomePageActions,
+  ChatsApiActions,
+  ChatsSocketActions,
+} from '../../home/actions';
 import { ApiService } from '../services/api.service';
-import { ActionTypes } from '@chat-app/api-interface';
+import { ActionTypes, IChat } from '@chat-app/api-interface';
 
 @Injectable()
 export class ChatsEffects {
@@ -54,6 +58,15 @@ export class ChatsEffects {
     {
       dispatch: false,
     }
+  );
+
+  chatStarted$ = createEffect(() =>
+    this.socket.fromEvent<{ chat: IChat }>(ActionTypes.ChatStarted).pipe(
+      tap(({ chat }) =>
+        this.router.navigate([''], { queryParams: { chatId: chat._id } })
+      ),
+      map(({ chat }) => ChatsSocketActions.chatStarted({ chat }))
+    )
   );
 
   constructor(

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -36,6 +36,20 @@ export class ChatsEffects {
     { dispatch: false }
   );
 
+  clearChat$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(HomePageActions.clearChat),
+        map(() =>
+          this.router.navigate([''], {
+            queryParams: { chatId: undefined },
+            queryParamsHandling: 'merge',
+          })
+        )
+      ),
+    { dispatch: false }
+  );
+
   sendMessage$ = createEffect(() =>
     this.actions$.pipe(
       ofType(HomePageActions.sendMessage),

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -2,9 +2,11 @@ import { Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { createEffect, Actions, ofType } from '@ngrx/effects';
 import { map, mergeMap, tap } from 'rxjs/operators';
+import { Socket } from 'ngx-socket-io';
 
 import { HomePageActions, ChatsApiActions } from '../../home/actions';
 import { ApiService } from '../services/api.service';
+import { ActionTypes } from '@chat-app/api-interface';
 
 @Injectable()
 export class ChatsEffects {
@@ -41,7 +43,21 @@ export class ChatsEffects {
     )
   );
 
+  startChat$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(HomePageActions.startChat),
+        tap(({ participants }) =>
+          this.socket.emit(ActionTypes.StartChat, { participants })
+        )
+      ),
+    {
+      dispatch: false,
+    }
+  );
+
   constructor(
+    private socket: Socket,
     private actions$: Actions,
     private apiService: ApiService,
     private router: Router

--- a/apps/web-client/src/app/core/state/chats.reducer.ts
+++ b/apps/web-client/src/app/core/state/chats.reducer.ts
@@ -1,7 +1,11 @@
 import { createReducer, on, Action } from '@ngrx/store';
 import { IChat, IMessage, IUser, IChatTab } from '@chat-app/api-interface';
 
-import { HomePageActions, ChatsApiActions } from '../../home/actions';
+import {
+  HomePageActions,
+  ChatsApiActions,
+  ChatsSocketActions,
+} from '../../home/actions';
 
 export interface State {
   data: IChat[] | null;
@@ -47,7 +51,17 @@ const chatReducer = createReducer(
           ...chat,
           messages: [...chat.messages, action.message],
         })),
-  }))
+  })),
+  on(ChatsSocketActions.chatStarted, (state, action) => {
+    if (!state.data) {
+      return state;
+    }
+
+    return {
+      ...state,
+      data: [...state.data, action.chat],
+    };
+  })
 );
 
 export function reducer(state = initialState, action: Action) {

--- a/apps/web-client/src/app/core/state/chats.reducer.ts
+++ b/apps/web-client/src/app/core/state/chats.reducer.ts
@@ -31,6 +31,10 @@ const chatReducer = createReducer(
     ...state,
     activeId: action.chatId,
   })),
+  on(HomePageActions.clearChat, (state) => ({
+    ...state,
+    activeId: null,
+  })),
   on(ChatsApiActions.getChatsSuccess, (state, action) => ({
     ...state,
     pending: false,

--- a/apps/web-client/src/app/home/actions/chats-socket.actions.ts
+++ b/apps/web-client/src/app/home/actions/chats-socket.actions.ts
@@ -1,7 +1,11 @@
 import { createAction, props } from '@ngrx/store';
-import { IUser } from '@chat-app/api-interface';
+import { IChat, IUser } from '@chat-app/api-interface';
 
 export const clientsUpdated = createAction(
   '[ChatsSocket] Clients Updated',
   props<{ clients: IUser[] }>()
+);
+export const chatStarted = createAction(
+  '[ChatsSocket] Chat Started',
+  props<{ chat: IChat }>()
 );

--- a/apps/web-client/src/app/home/actions/home-page.actions.ts
+++ b/apps/web-client/src/app/home/actions/home-page.actions.ts
@@ -1,3 +1,4 @@
+import { IUser } from '@chat-app/api-interface';
 import { createAction, props } from '@ngrx/store';
 
 export const enterPage = createAction('[HomePage] Enter Page');
@@ -8,4 +9,8 @@ export const activateChat = createAction(
 export const sendMessage = createAction(
   '[HomePage] Send Message',
   props<{ chatId: string; body: string }>()
+);
+export const startChat = createAction(
+  '[HomePage] Start Chat',
+  props<{ participants: [IUser, IUser] }>()
 );

--- a/apps/web-client/src/app/home/actions/home-page.actions.ts
+++ b/apps/web-client/src/app/home/actions/home-page.actions.ts
@@ -6,6 +6,7 @@ export const activateChat = createAction(
   '[HomePage] Activate Chat',
   props<{ chatId: string }>()
 );
+export const clearChat = createAction('[HomePage] Clear Chat');
 export const sendMessage = createAction(
   '[HomePage] Send Message',
   props<{ chatId: string; body: string }>()

--- a/apps/web-client/src/app/home/components/clients/clients.component.html
+++ b/apps/web-client/src/app/home/components/clients/clients.component.html
@@ -2,6 +2,7 @@
   *ngFor="let client of clients"
   class="w-full flex border-b-2 border-gray-400"
   style="height: 72px; padding: 10px;"
+  (click)="onStartChat(client)"
 >
   <wc-thumbnail [url]="client?.thumbnail || null"></wc-thumbnail>
   <div style="width: 230px;" class="pl-4">

--- a/apps/web-client/src/app/home/components/clients/clients.component.ts
+++ b/apps/web-client/src/app/home/components/clients/clients.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IUser } from '@chat-app/api-interface';
 
 @Component({
@@ -8,4 +8,13 @@ import { IUser } from '@chat-app/api-interface';
 export class ClientsComponent {
   @Input() clients!: IUser[] | null;
   @Input() currentUser!: IUser | null;
+  @Output() startChat = new EventEmitter<[IUser, IUser]>();
+
+  onStartChat(user: IUser) {
+    if (!this.currentUser) {
+      return;
+    }
+
+    this.startChat.emit([this.currentUser, user]);
+  }
 }

--- a/apps/web-client/src/app/home/home.component.html
+++ b/apps/web-client/src/app/home/home.component.html
@@ -21,6 +21,7 @@
         *ngIf="isShowingClients$ | async"
         [clients]="clients$ | async"
         [currentUser]="currentUser$ | async"
+        (startChat)="onStartChat($event)"
       ></wc-clients>
     </aside>
 

--- a/apps/web-client/src/app/home/home.component.ts
+++ b/apps/web-client/src/app/home/home.component.ts
@@ -35,17 +35,21 @@ export class HomeComponent implements OnInit {
   ngOnInit() {
     this.store.dispatch(HomePageActions.enterPage());
 
-    this.route.queryParams
-      .pipe(
-        map(({ chatId }) => chatId),
-        filter((chatId) => chatId),
-        take(1)
-      )
-      .subscribe((chatId) => this.onActivateChat(chatId));
+    this.route.queryParams.subscribe(({ chatId }) => {
+      if (chatId) {
+        this.onActivateChat(chatId);
+      } else {
+        this.onClearChat();
+      }
+    });
   }
 
   onActivateChat(chatId: string) {
     this.store.dispatch(HomePageActions.activateChat({ chatId }));
+  }
+
+  onClearChat() {
+    this.store.dispatch(HomePageActions.clearChat());
   }
 
   onSendMessage(chatId: string, body: string) {

--- a/apps/web-client/src/app/home/home.component.ts
+++ b/apps/web-client/src/app/home/home.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { IUser } from '@chat-app/api-interface';
 import { Store } from '@ngrx/store';
 import { filter, map, take } from 'rxjs/operators';
 
@@ -56,5 +57,9 @@ export class HomeComponent implements OnInit {
       queryParams: { isShowingClients: previousValue ? undefined : true },
       queryParamsHandling: 'merge',
     });
+  }
+
+  onStartChat(participants: [IUser, IUser]) {
+    this.store.dispatch(HomePageActions.startChat({ participants }));
   }
 }

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -28,4 +28,5 @@ export enum ActionTypes {
   Connect = '[Web Client] Connect',
   ClientsUpdated = '[Socket] Clients Updated',
   StartChat = '[Web Client] Start Chat',
+  ChatStarted = '[Socket] Chat Started',
 }

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -27,4 +27,5 @@ export interface IChatTab {
 export enum ActionTypes {
   Connect = '[Web Client] Connect',
   ClientsUpdated = '[Socket] Clients Updated',
+  StartChat = '[Web Client] Start Chat',
 }


### PR DESCRIPTION
The intention of this PR is to introduce a mechanism to start chats via the web client via the socket connection.

- Emit a socket event **startChat** from the **web-client**.
- Create a consumer for the **startChat** event in the **comm** service.
- Create chat via **API** through the **comm** service
- Add chat participants to a socket room named after the chat._id.
- Emit **chatStarted** event to participants via the socket room and set up a consumer for the **chatStarted** event in **the web-client**.
- Make sure the newly created chat gets auto-activated.