### PR TITLE
Task #005 | Manage delete chat via socket

### DIFF
--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -58,4 +58,9 @@ export class AppGateway {
         this.server.to(chat._id).emit(ActionTypes.ChatStarted, { chat });
       });
   }
+
+  @SubscribeMessage(ActionTypes.DeleteChat)
+  deleteChat(@MessageBody() payload: { chatId: string }) {
+    this.logger.log(`Delete Chat ${payload.chatId}`);
+  }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -66,6 +66,10 @@ export class AppGateway {
       .delete<{ chatId: string }>(
         `http://localhost:3333/api/chats/${payload.chatId}`
       )
-      .subscribe();
+      .subscribe(() =>
+        this.server
+          .to(payload.chatId)
+          .emit(ActionTypes.ChatDeleted, { chatId: payload.chatId })
+      );
   }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -62,5 +62,10 @@ export class AppGateway {
   @SubscribeMessage(ActionTypes.DeleteChat)
   deleteChat(@MessageBody() payload: { chatId: string }) {
     this.logger.log(`Delete Chat ${payload.chatId}`);
+    this.httpService
+      .delete<{ chatId: string }>(
+        `http://localhost:3333/api/chats/${payload.chatId}`
+      )
+      .subscribe();
   }
 }

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -82,6 +82,18 @@ export class ChatsEffects {
     }
   );
 
+  chatDeleted$ = createEffect(() =>
+    this.socket.fromEvent<{ chatId: string }>(ActionTypes.ChatDeleted).pipe(
+      tap(() =>
+        this.router.navigate([''], {
+          queryParams: { chatId: undefined },
+          queryParamsHandling: 'merge',
+        })
+      ),
+      map(({ chatId }) => ChatsSocketActions.chatDeleted({ chatId }))
+    )
+  );
+
   constructor(
     private socket: Socket,
     private actions$: Actions,

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -69,6 +69,19 @@ export class ChatsEffects {
     )
   );
 
+  deleteChat$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(HomePageActions.deleteChat),
+        tap(({ chatId }) =>
+          this.socket.emit(ActionTypes.DeleteChat, { chatId })
+        )
+      ),
+    {
+      dispatch: false,
+    }
+  );
+
   constructor(
     private socket: Socket,
     private actions$: Actions,

--- a/apps/web-client/src/app/core/state/chats.reducer.ts
+++ b/apps/web-client/src/app/core/state/chats.reducer.ts
@@ -61,6 +61,16 @@ const chatReducer = createReducer(
       ...state,
       data: [...state.data, action.chat],
     };
+  }),
+  on(ChatsSocketActions.chatDeleted, (state, action) => {
+    if (!state.data) {
+      return state;
+    }
+
+    return {
+      ...state,
+      data: state.data.filter((chat) => chat._id !== action.chatId),
+    };
   })
 );
 

--- a/apps/web-client/src/app/home/actions/chats-socket.actions.ts
+++ b/apps/web-client/src/app/home/actions/chats-socket.actions.ts
@@ -9,3 +9,7 @@ export const chatStarted = createAction(
   '[ChatsSocket] Chat Started',
   props<{ chat: IChat }>()
 );
+export const chatDeleted = createAction(
+  '[ChatsSocket] Chat Deleted',
+  props<{ chatId: string }>()
+);

--- a/apps/web-client/src/app/home/actions/home-page.actions.ts
+++ b/apps/web-client/src/app/home/actions/home-page.actions.ts
@@ -14,3 +14,7 @@ export const startChat = createAction(
   '[HomePage] Start Chat',
   props<{ participants: [IUser, IUser] }>()
 );
+export const deleteChat = createAction(
+  '[HomePage] Delete Chat',
+  props<{ chatId: string }>()
+);

--- a/apps/web-client/src/app/home/components/header/header.component.html
+++ b/apps/web-client/src/app/home/components/header/header.component.html
@@ -27,6 +27,13 @@
           {{ receiver?.username }}
         </p>
       </div>
+      <button
+        *ngIf="activeChatId"
+        class="text-2xl px-2 mr-4"
+        (click)="onDeleteChat(activeChatId)"
+      >
+        X
+      </button>
     </div>
   </div>
 </div>

--- a/apps/web-client/src/app/home/components/header/header.component.ts
+++ b/apps/web-client/src/app/home/components/header/header.component.ts
@@ -8,11 +8,19 @@ import { IUser } from '@chat-app/api-interface';
 export class HeaderComponent {
   @Input() currentUser!: IUser | null;
   @Input() receiver!: IUser | null;
+  @Input() activeChatId!: string | null;
   @Input() isShowingClients: boolean | null = false;
   @Input() hasReceivers: boolean | null = false;
   @Output() toggleShowClients = new EventEmitter<boolean | undefined>();
+  @Output() deleteChat = new EventEmitter<string>();
 
   onToggleShowClients() {
     this.toggleShowClients.emit(this.isShowingClients || undefined);
+  }
+
+  onDeleteChat(chatId: string) {
+    if (confirm('Are you sure about this? This action cannot be reverted.')) {
+      this.deleteChat.emit(chatId);
+    }
   }
 }

--- a/apps/web-client/src/app/home/home.component.html
+++ b/apps/web-client/src/app/home/home.component.html
@@ -5,7 +5,9 @@
       [currentUser]="currentUser$ | async"
       [isShowingClients]="isShowingClients$ | async"
       [hasReceivers]="hasReceivers$ | async"
+      [activeChatId]="activeChatId$ | async"
       (toggleShowClients)="onToggleShowClients($event)"
+      (deleteChat)="onDeleteChat($event)"
     ></wc-header>
   </header>
 

--- a/apps/web-client/src/app/home/home.component.ts
+++ b/apps/web-client/src/app/home/home.component.ts
@@ -62,4 +62,8 @@ export class HomeComponent implements OnInit {
   onStartChat(participants: [IUser, IUser]) {
     this.store.dispatch(HomePageActions.startChat({ participants }));
   }
+
+  onDeleteChat(chatId: string) {
+    this.store.dispatch(HomePageActions.deleteChat({ chatId }));
+  }
 }

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -29,4 +29,5 @@ export enum ActionTypes {
   ClientsUpdated = '[Socket] Clients Updated',
   StartChat = '[Web Client] Start Chat',
   ChatStarted = '[Socket] Chat Started',
+  DeleteChat = '[Web Client] Delete Chat',
 }

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -30,4 +30,5 @@ export enum ActionTypes {
   StartChat = '[Web Client] Start Chat',
   ChatStarted = '[Socket] Chat Started',
   DeleteChat = '[Web Client] Delete Chat',
+  ChatDeleted = '[Socket] Chat Deleted',
 }


### PR DESCRIPTION
The intention of this PR is to introduce a mechanism to delete chats via the socket connection.

- Emit a socket event **deleteChat** from the **web-client**.
- Create a consumer for the **deleteChat** event in the **comm** service.
- Delete chat via **API** through the **comm** service
- Emit **chatDeleted** event to participants via the socket room and set up a consumer for the **chatDeleted** event in **the web-client**.