### PR TITLE
Task #006 | Manage send message via socket

### DIFF
--- a/apps/api/src/app/chat/message/message.controller.ts
+++ b/apps/api/src/app/chat/message/message.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Post,
-  Body,
-  Headers,
-  Param,
-  HttpCode,
-} from '@nestjs/common';
+import { Controller, Post, Body, Param, HttpCode } from '@nestjs/common';
 
 import { MessageService } from './message.service';
 
@@ -17,7 +10,7 @@ export class MessageController {
   @HttpCode(200)
   sendMessage(
     @Param('chat_id') chatId: string,
-    @Headers('id') authorId: string,
+    @Body('authorId') authorId: string,
     @Body('body') body: string
   ) {
     return this.messageService.sendMessage(chatId, authorId, body);

--- a/apps/api/src/app/chat/message/message.schema.ts
+++ b/apps/api/src/app/chat/message/message.schema.ts
@@ -13,6 +13,9 @@ export class Message {
 
   @Prop()
   authorId: MongooseSchema.Types.ObjectId;
+
+  @Prop()
+  chatId: MongooseSchema.Types.ObjectId;
 }
 
 export const MessageSchema = SchemaFactory.createForClass(Message);

--- a/apps/api/src/app/chat/message/message.service.ts
+++ b/apps/api/src/app/chat/message/message.service.ts
@@ -17,6 +17,7 @@ export class MessageService {
       body,
       date: new Date(Date.now()),
       authorId,
+      chatId,
     }).toObject();
 
     await this.chatModel.updateOne(

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -72,4 +72,11 @@ export class AppGateway {
           .emit(ActionTypes.ChatDeleted, { chatId: payload.chatId })
       );
   }
+
+  @SubscribeMessage(ActionTypes.SendMessage)
+  sendMessage(
+    @MessageBody() payload: { authorId: string; chatId: string; body: string }
+  ) {
+    this.logger.log(`Send Message to chat ${payload.chatId}`);
+  }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
 import { HttpService, Logger } from '@nestjs/common';
-import { IUser, ActionTypes, IChat } from '@chat-app/api-interface';
+import { IUser, ActionTypes, IChat, IMessage } from '@chat-app/api-interface';
 
 @WebSocketGateway()
 export class AppGateway {
@@ -78,5 +78,11 @@ export class AppGateway {
     @MessageBody() payload: { authorId: string; chatId: string; body: string }
   ) {
     this.logger.log(`Send Message to chat ${payload.chatId}`);
+    this.httpService
+      .post<IMessage>(
+        `http://localhost:3333/api/chats/${payload.chatId}/messages`,
+        { authorId: payload.authorId, body: payload.body }
+      )
+      .subscribe();
   }
 }

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -37,7 +37,16 @@ export class AppGateway {
     this.logger.log(
       `Connect: ${payload.username} (${payload._id}/${client.id}) - ${this.connectedClients.length} connected clients.`
     );
-    this.server.emit(ActionTypes.ClientsUpdated, this.connectedClients);
+    this.httpService
+      .get<IChat[]>('http://localhost:3333/api/chats', {
+        headers: { id: payload._id },
+      })
+      .subscribe(({ data: chats }) => {
+        // Join every chat room where the user is part of
+        chats.forEach((chat) => client.join(chat._id));
+        // Emit to every client the full list of connected clients
+        this.server.emit(ActionTypes.ClientsUpdated, this.connectedClients);
+      });
   }
 
   @SubscribeMessage(ActionTypes.StartChat)

--- a/apps/comm/src/app/app.gateway.ts
+++ b/apps/comm/src/app/app.gateway.ts
@@ -92,6 +92,10 @@ export class AppGateway {
         `http://localhost:3333/api/chats/${payload.chatId}/messages`,
         { authorId: payload.authorId, body: payload.body }
       )
-      .subscribe();
+      .subscribe(({ data: message }) =>
+        this.server
+          .to(payload.chatId)
+          .emit(ActionTypes.MessageSent, { message })
+      );
   }
 }

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -10,7 +10,7 @@ import {
   ChatsSocketActions,
 } from '../../home/actions';
 import { ApiService } from '../services/api.service';
-import { ActionTypes, IChat } from '@chat-app/api-interface';
+import { ActionTypes, IChat, IMessage } from '@chat-app/api-interface';
 
 @Injectable()
 export class ChatsEffects {
@@ -61,6 +61,12 @@ export class ChatsEffects {
     {
       dispatch: false,
     }
+  );
+
+  messageSent$ = createEffect(() =>
+    this.socket
+      .fromEvent<{ message: IMessage }>(ActionTypes.MessageSent)
+      .pipe(map(({ message }) => ChatsSocketActions.messageSent({ message })))
   );
 
   startChat$ = createEffect(

--- a/apps/web-client/src/app/core/effects/chats.effects.ts
+++ b/apps/web-client/src/app/core/effects/chats.effects.ts
@@ -50,15 +50,17 @@ export class ChatsEffects {
     { dispatch: false }
   );
 
-  sendMessage$ = createEffect(() =>
-    this.actions$.pipe(
-      ofType(HomePageActions.sendMessage),
-      mergeMap(({ chatId, body }) =>
-        this.apiService
-          .sendMessage(chatId, body)
-          .pipe(map((message) => ChatsApiActions.messageSent({ message })))
-      )
-    )
+  sendMessage$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(HomePageActions.sendMessage),
+        tap(({ authorId, chatId, body }) =>
+          this.socket.emit(ActionTypes.SendMessage, { authorId, chatId, body })
+        )
+      ),
+    {
+      dispatch: false,
+    }
   );
 
   startChat$ = createEffect(

--- a/apps/web-client/src/app/core/services/api.service.ts
+++ b/apps/web-client/src/app/core/services/api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { IChat, IMessage, IUser } from '@chat-app/api-interface';
+import { IChat, IUser } from '@chat-app/api-interface';
 
 @Injectable({ providedIn: 'root' })
 export class ApiService {
@@ -8,12 +8,6 @@ export class ApiService {
 
   getChats() {
     return this.httpClient.get<IChat[]>('/api/chats');
-  }
-
-  sendMessage(chatId: string, body: string) {
-    return this.httpClient.post<IMessage>(`/api/chats/${chatId}/messages`, {
-      body,
-    });
   }
 
   login(username: string) {

--- a/apps/web-client/src/app/core/state/chats.reducer.ts
+++ b/apps/web-client/src/app/core/state/chats.reducer.ts
@@ -47,14 +47,18 @@ const chatReducer = createReducer(
     error: action.error,
     data: null,
   })),
-  on(ChatsApiActions.messageSent, (state, action) => ({
+  on(ChatsSocketActions.messageSent, (state, action) => ({
     ...state,
     data: !state.data
       ? null
-      : state.data.map((chat) => ({
-          ...chat,
-          messages: [...chat.messages, action.message],
-        })),
+      : state.data.map((chat) =>
+          chat._id === action.message.chatId
+            ? {
+                ...chat,
+                messages: [...chat.messages, action.message],
+              }
+            : chat
+        ),
   })),
   on(ChatsSocketActions.chatStarted, (state, action) => {
     if (!state.data) {

--- a/apps/web-client/src/app/home/actions/chats-socket.actions.ts
+++ b/apps/web-client/src/app/home/actions/chats-socket.actions.ts
@@ -1,5 +1,5 @@
 import { createAction, props } from '@ngrx/store';
-import { IChat, IUser } from '@chat-app/api-interface';
+import { IChat, IMessage, IUser } from '@chat-app/api-interface';
 
 export const clientsUpdated = createAction(
   '[ChatsSocket] Clients Updated',
@@ -12,4 +12,8 @@ export const chatStarted = createAction(
 export const chatDeleted = createAction(
   '[ChatsSocket] Chat Deleted',
   props<{ chatId: string }>()
+);
+export const messageSent = createAction(
+  '[ChatsSocket] Chat Sent',
+  props<{ message: IMessage }>()
 );

--- a/apps/web-client/src/app/home/actions/home-page.actions.ts
+++ b/apps/web-client/src/app/home/actions/home-page.actions.ts
@@ -9,7 +9,7 @@ export const activateChat = createAction(
 export const clearChat = createAction('[HomePage] Clear Chat');
 export const sendMessage = createAction(
   '[HomePage] Send Message',
-  props<{ chatId: string; body: string }>()
+  props<{ authorId: string; chatId: string; body: string }>()
 );
 export const startChat = createAction(
   '[HomePage] Start Chat',

--- a/apps/web-client/src/app/home/components/chat/chat.component.ts
+++ b/apps/web-client/src/app/home/components/chat/chat.component.ts
@@ -18,7 +18,11 @@ import { IChat, IUser } from '@chat-app/api-interface';
 export class ChatComponent implements OnChanges {
   @Input() currentUser!: IUser | null;
   @Input() chat!: IChat | null;
-  @Output() sendMessage = new EventEmitter<{ chatId: string; body: string }>();
+  @Output() sendMessage = new EventEmitter<{
+    authorId: string;
+    chatId: string;
+    body: string;
+  }>();
   @ViewChild('chatInput') chatInput!: ElementRef<any>;
   chatGroup = this.fb.group({
     body: ['', [Validators.required]],
@@ -33,13 +37,13 @@ export class ChatComponent implements OnChanges {
   }
 
   onSendMessage(chatId?: string) {
-    if (this.chatGroup.invalid || !chatId) {
+    if (this.chatGroup.invalid || !chatId || !this.currentUser) {
       return;
     }
 
     const { body } = this.chatGroup.value;
 
-    this.sendMessage.emit({ chatId, body });
+    this.sendMessage.emit({ authorId: this.currentUser._id, chatId, body });
     this.chatInput.nativeElement.focus();
     this.chatGroup.reset();
   }

--- a/apps/web-client/src/app/home/home.component.html
+++ b/apps/web-client/src/app/home/home.component.html
@@ -32,7 +32,9 @@
         *ngIf="chat$ | async as chat"
         [chat]="chat"
         [currentUser]="currentUser$ | async"
-        (sendMessage)="onSendMessage($event.chatId, $event.body)"
+        (sendMessage)="
+          onSendMessage($event.authorId, $event.chatId, $event.body)
+        "
       ></wc-chat>
     </main>
   </div>

--- a/apps/web-client/src/app/home/home.component.ts
+++ b/apps/web-client/src/app/home/home.component.ts
@@ -52,8 +52,10 @@ export class HomeComponent implements OnInit {
     this.store.dispatch(HomePageActions.clearChat());
   }
 
-  onSendMessage(chatId: string, body: string) {
-    this.store.dispatch(HomePageActions.sendMessage({ chatId, body }));
+  onSendMessage(authorId: string, chatId: string, body: string) {
+    this.store.dispatch(
+      HomePageActions.sendMessage({ authorId, chatId, body })
+    );
   }
 
   onToggleShowClients(previousValue: boolean | undefined) {

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -2,6 +2,7 @@ export interface IMessage {
   body: string;
   date: Date;
   authorId: string;
+  chatId: string;
 }
 
 export interface IUser {

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -33,4 +33,5 @@ export enum ActionTypes {
   DeleteChat = '[Web Client] Delete Chat',
   ChatDeleted = '[Socket] Chat Deleted',
   SendMessage = '[Web Client] Send Message',
+  MessageSent = '[Socket] Message Sent',
 }

--- a/libs/api-interface/src/lib/api-interface.ts
+++ b/libs/api-interface/src/lib/api-interface.ts
@@ -31,4 +31,5 @@ export enum ActionTypes {
   ChatStarted = '[Socket] Chat Started',
   DeleteChat = '[Web Client] Delete Chat',
   ChatDeleted = '[Socket] Chat Deleted',
+  SendMessage = '[Web Client] Send Message',
 }


### PR DESCRIPTION
The intention of this PR is to introduce a mechanism to send messages via the socket connection.

The intention of this PR is to introduce a mechanism to delete chats via the socket connection.

- Emit a socket event **sendMessage** from the **web-client** instead of calling the **API** directly.
- Create a consumer for the **sendMessage** event in the **comm** service.
- Create message via **API** through the **comm** service
- Add chatId property to messages.
- Make sure the user is added to every chat it belongs to upon establishing the connection.
- Emit **messageSent** event to participants via the socket room and set up a consumer for the **messageSent** event in the web-client.